### PR TITLE
전체조회 api 페이징 처리

### DIFF
--- a/src/main/kotlin/com/api/wallet/controller/WalletController.kt
+++ b/src/main/kotlin/com/api/wallet/controller/WalletController.kt
@@ -3,7 +3,9 @@ package com.api.wallet.controller
 import com.api.wallet.validator.SignatureValidator
 import com.api.wallet.controller.dto.request.ValidateRequest
 import com.api.wallet.service.api.WalletService
+import com.api.wallet.service.api.WalletTransactionService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/wallet")
 class WalletController(
     private val walletService: WalletService,
+    private val walletTransactionService: WalletTransactionService,
 ) {
     // 지갑 유효성 검증
     // 검증에 실패할 경우 return error
@@ -26,5 +29,10 @@ class WalletController(
 //        }
         return ResponseEntity.badRequest().body("Wallet authenticated fail")
     }
+
+//    @GetMapping("")
+//    fun getTransactionsByWallet() {
+//
+//    }
 
 }

--- a/src/main/kotlin/com/api/wallet/domain/transaction/repository/TransactionRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/transaction/repository/TransactionRepository.kt
@@ -1,11 +1,12 @@
 package com.api.wallet.domain.transaction.repository
 
 import com.api.wallet.domain.transaction.Transaction
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
 interface TransactionRepository: ReactiveCrudRepository<Transaction,Long> {
 
-    fun findAllByWalletIdOrderByBlockTimestampDesc(address: String): Flux<Transaction>
+    fun findAllByWalletIdOrderByBlockTimestampDesc(address: String,pageable: Pageable?): Flux<Transaction>
 
 }

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
@@ -1,13 +1,14 @@
 package com.api.wallet.domain.walletNft.repository
 
 import com.api.wallet.domain.walletNft.WalletNft
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 interface WalletNftRepository : ReactiveCrudRepository<WalletNft,Long> {
 
-    fun findByWalletId(address: String): Flux<WalletNft>
+    fun findByWalletId(address: String,pageable: Pageable?): Flux<WalletNft>
 
     fun deleteByNftIdAndWalletId(tokenAddress: String,walletAddress: String): Mono<Void>
 }

--- a/src/main/kotlin/com/api/wallet/service/api/NftService.kt
+++ b/src/main/kotlin/com/api/wallet/service/api/NftService.kt
@@ -6,10 +6,15 @@ import com.api.wallet.domain.wallet.Wallet
 import com.api.wallet.domain.wallet.repository.WalletRepository
 import com.api.wallet.domain.walletNft.WalletNft
 import com.api.wallet.domain.walletNft.repository.WalletNftRepository
+import com.api.wallet.enums.NetworkType
 import com.api.wallet.service.moralis.MoralisService
 import com.api.wallet.service.moralis.dto.response.NFTResult
 import com.api.wallet.util.Util.convertNetworkTypeToChainType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -28,26 +33,38 @@ class NftService(
             ))
     }
 
+
     //TODO("반환값 재정의 : nft: 메타데이터 필요")
-    fun readAllNftByWallet(address: String): Flux<WalletNft> {
-        return walletRepository.findAllByAddress(address).flatMap { wallet ->
-            getNftByWallet(wallet)
+    @Transactional
+    fun readAllNftByWallet(address: String, networkType:NetworkType?, pageable: Pageable): Mono<Page<WalletNft>> {
+        val wallets = if (networkType != null) {
+            walletRepository.findByAddressAndNetworkType(address, networkType.toString()).flux()
+        } else {
+            walletRepository.findAllByAddress(address)
         }
+
+        return wallets
+            .flatMap { wallet ->
+                getNftByWallet(wallet, pageable)
+            }
+            .collectList()
+            .zipWith(walletNftRepository.count())
+            .map { PageImpl(it.t1, pageable, it.t2) }
+
     }
 
-    private fun getNftByWallet(wallet: Wallet): Flux<WalletNft> {
+    private fun getNftByWallet(wallet: Wallet, pageable: Pageable): Flux<WalletNft> {
         val response = moralisService.getNFTsByAddress(wallet.address, wallet.networkType.convertNetworkTypeToChainType())
-        val getNftsByWallet = walletNftRepository.findByWalletId(wallet.address)
+        val getNftsByWallet = walletNftRepository.findByWalletId(wallet.address,pageable)
 
         return Mono.zip(response, getNftsByWallet.collectList())
             .flatMapMany { tuple ->
                 val responseNfts = tuple.t1.result.associateBy { it.tokenAddress }
                 val getNfts = tuple.t2.associateBy { it.nftId }
 
-                val addFlux = addToWalletNft(responseNfts, getNfts, wallet)
-
                 deleteToWalletNft(responseNfts, getNfts, wallet)
-                    .thenMany(addFlux)
+                    .thenMany(addToWalletNft(responseNfts, getNfts, wallet))
+                    .thenMany(walletNftRepository.findByWalletId(wallet.address,pageable))
             }
     }
 

--- a/src/main/kotlin/com/api/wallet/service/api/WalletTransactionService.kt
+++ b/src/main/kotlin/com/api/wallet/service/api/WalletTransactionService.kt
@@ -4,14 +4,20 @@ import com.api.wallet.domain.transaction.Transaction
 import com.api.wallet.domain.transaction.repository.TransactionRepository
 import com.api.wallet.domain.wallet.Wallet
 import com.api.wallet.domain.wallet.repository.WalletRepository
+import com.api.wallet.enums.ChainType
+import com.api.wallet.enums.NetworkType
 import com.api.wallet.service.moralis.MoralisService
 import com.api.wallet.service.moralis.dto.response.TransferResult
 import com.api.wallet.util.Util.convertNetworkTypeToChainType
 import com.api.wallet.util.Util.toIsoString
 import com.api.wallet.util.Util.toTimestamp
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
 class WalletTransactionService(
@@ -20,33 +26,47 @@ class WalletTransactionService(
     private val walletRepository: WalletRepository,
     private val nftService: NftService,
 ) {
-    //TODO("페이징 처리")
     //TODO("반환값 재정의 : nft 메타데이터 필요")
     @Transactional
-    fun readAllTransactions(address: String) : Flux<Transaction> {
-        return walletRepository.findAllByAddress(address).flatMap { wallet->
-            getTransactions(wallet)
+    fun readAllTransactions(address: String, networkType: NetworkType?, pageable: Pageable): Mono<Page<Transaction>> {
+        val wallets = if (networkType != null) {
+            walletRepository.findByAddressAndNetworkType(address, networkType.toString()).flux()
+        } else {
+            walletRepository.findAllByAddress(address)
         }
-    }
 
-    private fun getTransactions(wallet: Wallet) : Flux<Transaction> {
-        val transactions = transactionRepository.findAllByWalletIdOrderByBlockTimestampDesc(wallet.address)
+        return wallets
+            .flatMap { wallet ->
+                getTransactions(wallet, pageable)
+            }
             .collectList()
-
-       return transactions.flatMapMany { transaction ->
-            val lastBlockTimestamp = transaction.firstOrNull()?.blockTimestamp?.plus(10000)
-
-            val response = moralisService.getWalletNFTTransfers(
-                wallet.address,
-                wallet.networkType.convertNetworkTypeToChainType(),
-                lastBlockTimestamp?.toIsoString() ?: null,
-                System.currentTimeMillis().toIsoString()
-            ).flatMapMany { Flux.fromIterable(it.result) }
-                .filter { !it.possibleSpam }
-
-          saveOrUpdate(response,wallet)
-        }
+            .zipWith(transactionRepository.count())
+            .map { PageImpl(it.t1, pageable, it.t2) }
     }
+
+    private fun getTransactions(wallet: Wallet, pageable: Pageable): Flux<Transaction> {
+        val updateFlux = transactionRepository.findAllByWalletIdOrderByBlockTimestampDesc(wallet.address,pageable)
+            .collectList()
+            .flatMapMany {
+                val lastBlockTimestamp = it.firstOrNull()?.blockTimestamp?.plus(10000)
+                moralisService.getWalletNFTTransfers(
+                    wallet.address,
+                    wallet.networkType.convertNetworkTypeToChainType(),
+                    lastBlockTimestamp?.toIsoString() ?: null,
+                    System.currentTimeMillis().toIsoString()
+                )
+                    .flatMapMany { Flux.fromIterable(it.result) }
+                    .filter { !it.possibleSpam }
+                    .flatMap { result ->
+                        saveOrUpdate(Flux.just(result), wallet)
+                    }
+            }
+
+        return updateFlux.thenMany(
+            transactionRepository.findAllByWalletIdOrderByBlockTimestampDesc(wallet.address, pageable)
+        )
+    }
+
 
 
     private fun saveOrUpdate(results: Flux<TransferResult>,wallet: Wallet): Flux<Transaction> {

--- a/src/test/kotlin/com/api/wallet/ValidatorTest.kt
+++ b/src/test/kotlin/com/api/wallet/ValidatorTest.kt
@@ -2,6 +2,7 @@ package com.api.wallet
 
 import com.api.wallet.controller.dto.request.ValidateRequest
 import com.api.wallet.domain.network.repository.NetworkRepository
+import com.api.wallet.domain.transaction.Transaction
 import com.api.wallet.domain.user.repository.UserRepository
 import com.api.wallet.domain.wallet.repository.WalletRepository
 import com.api.wallet.enums.ChainType
@@ -17,6 +18,9 @@ import com.api.wallet.validator.SignatureValidator
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import reactor.core.publisher.Flux
 import java.lang.System.currentTimeMillis
 
 
@@ -115,7 +119,15 @@ class ValidatorTest(
     @Test
     fun tansferasdas() {
         val address = "0x01b72b4aa3f66f213d62d53e829bc172a6a72867"
-        walletTransactionService.readAllTransactions(address).collectList().block()
+        val pagebale = PageRequest.of(0,2)
+        val networkType = NetworkType.POLYGON
+
+        val transaction: Page<Transaction>? = walletTransactionService.readAllTransactions(address,networkType,pagebale).block()
+            println("total element : "+transaction?.totalElements)
+            println("totalPages : " + transaction?.totalPages)
+        transaction?.content?.forEach {
+                println(it.nftId)
+            }
     }
 
     @Test
@@ -127,7 +139,15 @@ class ValidatorTest(
     @Test
     fun readAllNfts() {
         val address = "0x01b72b4aa3f66f213d62d53e829bc172a6a72867"
-        nftService.readAllNftByWallet(address).blockFirst()
+        val pagebale = PageRequest.of(0,3)
+        val nftList= nftService.readAllNftByWallet(address,null,pagebale).block()
+
+            println("total element : "+nftList?.totalElements)
+            println("totalPages : " + nftList?.totalPages)
+        nftList?.content?.forEach {
+                println(it.nftId)
+            }
+
     }
 
 


### PR DESCRIPTION
## 이슈번호 #6 

## readAll() 함수에서 pagination 적용하기
SpringDataJpa 에서는 JpaRepository 는 PagingAndSortingRepository 상속받은 인터페이스라 paging과 sort를 제공하지만 
**SpringDataReacive에서는 페이징을 완벽하게 지원하지 않는다고함**

### ReactiveCrudRepository 은  Paging을 지원하는 이유는 ?
 특정 페이지 크기에 대한 모든 데이터를 반환할 때까지 블록킹되야 하는데 Reacive는 비동기/논블럭킹이니 효율적이지 않음

### limt과 offset 을 지원하는 Pageable
Pageable 객체를 전달하면 limt,offset 를 가져올수 있다, 하지만 Page객체를 지원하지는 않음.
```kotlin

val pagebale = PageRequest.of(2,4)
val updateFlux = transactionRepository.findAllByWalletIdOrderByBlockTimestampDesc(wallet.address,pageable)


// 실행결과
2024-03-30T19:33:21.120+09:00 DEBUG 65613 --- [actor-tcp-nio-1] io.r2dbc.postgresql.QUERY                : [cid: 0x1][pid: 7009] Executing query: SELECT transaction.id, transaction.nft_id, transaction.to_address, transaction.from_address, transaction.amount, transaction.value, transaction.hash, transaction.block_timestamp, transaction.wallet_id FROM transaction WHERE transaction.wallet_id = $1 ORDER BY transaction.block_timestamp DESC LIMIT 4 OFFSET 8
```
디버깅결과 limit와 offset은 적용되지만 Page객체는 직접생성해줘야됨

* * *
### PageImpl 생성하기
```kotlin
 return wallets
            .flatMap { wallet ->
                getTransactions(wallet, pageable)
            }
            .collectList()
            .zipWith(transactionRepository.count())
            .map { PageImpl(it.t1, pageable, it.t2) }
```
getTransactions 은 Flux 반환이라 Page로 반환하기위한 Mono로 만들어줘야됨
전체데이터의 개수를 반환하기위해 count()쿼리 따로 조회
zipWith()로 getTransactions() 와 transactionRepository.count() 를 결합하여 page정보 반환





### **참고문서**
- https://www.baeldung.com/spring-data-webflux-pagination