### PR TITLE
readAllNftByWallet 전체조회페이징 이슈

### DIFF
--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
@@ -8,7 +8,7 @@ import reactor.core.publisher.Mono
 
 interface WalletNftRepository : ReactiveCrudRepository<WalletNft,Long> {
 
-    fun findByWalletId(address: String,pageable: Pageable?): Flux<WalletNft>
+    fun findByWalletId(address: String): Flux<WalletNft>
 
     fun deleteByNftIdAndWalletId(tokenAddress: String,walletAddress: String): Mono<Void>
 }

--- a/src/main/kotlin/com/api/wallet/service/moralis/dto/response/NFTByWalletResponse.kt
+++ b/src/main/kotlin/com/api/wallet/service/moralis/dto/response/NFTByWalletResponse.kt
@@ -19,7 +19,7 @@ data class NFTResult(
     @JsonProperty("owner_of") val ownerOf: String,
     @JsonProperty("block_number") val blockNumber: String,
     @JsonProperty("block_number_minted") val blockNumberMinted: String?,
-    @JsonProperty("token_uri") val tokenUri: String,
+    @JsonProperty("token_uri") val tokenUri: String?,
     val metadata: String?,
     @JsonProperty("normalized_metadata") val normalizedMetadata: String?,
     val media: String?,

--- a/src/test/kotlin/com/api/wallet/ValidatorTest.kt
+++ b/src/test/kotlin/com/api/wallet/ValidatorTest.kt
@@ -119,7 +119,7 @@ class ValidatorTest(
     @Test
     fun tansferasdas() {
         val address = "0x01b72b4aa3f66f213d62d53e829bc172a6a72867"
-        val pagebale = PageRequest.of(0,2)
+        val pagebale = PageRequest.of(2,4)
         val networkType = NetworkType.POLYGON
 
         val transaction: Page<Transaction>? = walletTransactionService.readAllTransactions(address,networkType,pagebale).block()


### PR DESCRIPTION
## 문제 발단
readAllNftByWallet 페이징 처리 후 새로 nft가 추가되지않았는데도 불구하고 DB에 적재되고있었음

## 문제 이유
페이징 구현 전에는 wallet에 해당하는 내 nft를 모두 가져온다음 외부api에서 가져온 데이터를 비교하여 
삭제, 추가 로직을 구현하여 요청할때마다 DB에 동기화를 해주고있었음
```kotlin
val response = moralisService.getNFTsByAddress(wallet.address, wallet.networkType.convertNetworkTypeToChainType()) 
val getNftsByWallet = walletNftRepository.findByWalletId(wallet.address, pageable) 
```
페이징 처리 후 getNftsByWallet에서 페이징된 데이터를 가져와 비교하려니까 현재 db에 존재해도 페이징되어 반환된 데이터에 해당 nft가 없기에 추가되는 문제가 발생함

## 처리방법 고민
1.  walletNftRepository.findByWalletId를 조회할때 pagable을 제거하여 모든 데이터를 로드 후 반활할때에만 페이징처리
2. 요청이 올때마다 walletNftRepository.findByWalletId 에 해당하는 데이터를 모두 삭제 후 외부 api로 가져온데이터로 덮어씌우고 페이징처리

## 최종선택
이미 삭제,추가 로직이 있으니 그냥 모두 로드한 후 page적용하기로함 






