### PR TITLE
nft와 wallet 중복 키 발생이슈

### DIFF
--- a/src/main/kotlin/com/api/wallet/domain/nft/Nft.kt
+++ b/src/main/kotlin/com/api/wallet/domain/nft/Nft.kt
@@ -5,7 +5,9 @@ import org.springframework.data.relational.core.mapping.Table
 
 @Table("nft")
 class Nft(
-    @Id val tokenAddress: String,
-    val networkType: String
+    @Id val id: Long? = null,
+    val tokenId: String,
+    val tokenAddress: String,
+    val networkType: String,
 ) {
 }

--- a/src/main/kotlin/com/api/wallet/domain/nft/repository/NftRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/nft/repository/NftRepository.kt
@@ -4,6 +4,7 @@ import com.api.wallet.domain.nft.Nft
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Mono
 
-interface NftRepository : ReactiveCrudRepository<Nft,String>, NftRepositorySupport {
-    fun findByTokenAddressAndNetworkType(address: String, networkType: String): Mono<Nft>
+interface NftRepository : ReactiveCrudRepository<Nft,Long>, NftRepositorySupport {
+
+    fun findByTokenAddressAndNetworkTypeAndTokenId(address: String, networkType: String,tokenId: String): Mono<Nft>
 }

--- a/src/main/kotlin/com/api/wallet/domain/transaction/Transaction.kt
+++ b/src/main/kotlin/com/api/wallet/domain/transaction/Transaction.kt
@@ -7,13 +7,13 @@ import java.math.BigDecimal
 @Table("transaction")
 class Transaction(
     @Id val id: Long? = null,
-    val nftId: String, // 외래키
+    val nftId: Long, // 외래키
     val toAddress: String,
     val fromAddress: String,
     val amount: Int,
     val value: BigDecimal,
     val hash: String?,
     val blockTimestamp: Long?,
-    val walletId: String?, // 외래키
+    val walletId: Long?, // 외래키
 ){
 }

--- a/src/main/kotlin/com/api/wallet/domain/transaction/repository/TransactionRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/transaction/repository/TransactionRepository.kt
@@ -7,6 +7,6 @@ import reactor.core.publisher.Flux
 
 interface TransactionRepository: ReactiveCrudRepository<Transaction,Long> {
 
-    fun findAllByWalletIdOrderByBlockTimestampDesc(address: String,pageable: Pageable?): Flux<Transaction>
+    fun findAllByWalletIdOrderByBlockTimestampDesc(walletId: Long,pageable: Pageable?): Flux<Transaction>
 
 }

--- a/src/main/kotlin/com/api/wallet/domain/wallet/Wallet.kt
+++ b/src/main/kotlin/com/api/wallet/domain/wallet/Wallet.kt
@@ -6,7 +6,8 @@ import java.math.BigDecimal
 
 @Table("wallet")
 data class Wallet(
-    @Id val address: String,
+    @Id val id: Long? = null,
+    val address: String,
     val userId: Long,
     val networkType: String,
     var balance: BigDecimal,

--- a/src/main/kotlin/com/api/wallet/domain/wallet/repository/WalletRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/wallet/repository/WalletRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface WalletRepository : ReactiveCrudRepository<Wallet,String>, WalletRepositorySupport {
+interface WalletRepository : ReactiveCrudRepository<Wallet,Long>, WalletRepositorySupport {
     fun findByAddressAndNetworkType(address: String, networkType: String): Mono<Wallet>
     fun findAllByAddress(address: String): Flux<Wallet>
 }

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/WalletNft.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/WalletNft.kt
@@ -6,7 +6,8 @@ import org.springframework.data.relational.core.mapping.Table
 @Table("wallet_nft")
 class WalletNft(
     @Id val id: Long? = null,
-    val walletId: String,
-    val nftId: String
+    val walletId: Long,
+    val nftId: Long,
+    val amount: Int,
 ) {
 }

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepository.kt
@@ -1,14 +1,16 @@
 package com.api.wallet.domain.walletNft.repository
 
 import com.api.wallet.domain.walletNft.WalletNft
+import com.api.wallet.enums.NetworkType
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface WalletNftRepository : ReactiveCrudRepository<WalletNft,Long> {
+interface WalletNftRepository : ReactiveCrudRepository<WalletNft,Long>, WalletNftRepositorySupport {
 
-    fun findByWalletId(address: String): Flux<WalletNft>
+    fun findByWalletId(walletId: Long): Flux<WalletNft>
 
-    fun deleteByNftIdAndWalletId(tokenAddress: String,walletAddress: String): Mono<Void>
+    fun deleteByNftIdAndWalletId(nftId: Long,walletId: Long): Mono<Void>
 }

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepositorySupport.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepositorySupport.kt
@@ -1,0 +1,10 @@
+package com.api.wallet.domain.walletNft.repository
+
+import com.api.wallet.enums.NetworkType
+import reactor.core.publisher.Flux
+
+interface WalletNftRepositorySupport {
+
+    fun findByWalletIdJoinNft(address: String, networkType: String) : Flux<WalletNftWithNft>
+
+}

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepositorySupportImpl.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftRepositorySupportImpl.kt
@@ -1,0 +1,40 @@
+package com.api.wallet.domain.walletNft.repository
+
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
+import reactor.core.publisher.Flux
+
+class WalletNftRepositorySupportImpl(
+    private val r2dbcEntityTemplate: R2dbcEntityTemplate
+): WalletNftRepositorySupport {
+
+
+    override fun findByWalletIdJoinNft(address: String, networkType: String): Flux<WalletNftWithNft> {
+        val query = """
+        SELECT 
+            wn.id AS wn_id, 
+            wn.wallet_id AS wallet_address, 
+            n.id AS nft_id, 
+            n.token_address AS nft_token_address, 
+            n.token_id AS nft_token_id 
+        FROM wallet_nft wn 
+        JOIN wallet w ON wn.wallet_id = w.id 
+        JOIN nft n ON wn.nft_id = n.id 
+        WHERE w.address = $1 AND w.network_type = $2
+    """
+
+        return r2dbcEntityTemplate.databaseClient.sql(query)
+            .bind(0, address)
+            .bind(1, networkType)
+            .map { row, metadata ->
+                WalletNftWithNft(
+                    id = (row.get("wn_id") as Number).toLong(),
+                    walletId = (row.get("wallet_id") as Number).toLong(),
+                    nftId = (row.get("nft_id") as Number).toLong(),
+                    nftTokenAddress = row.get("nft_token_address", String::class.java)!!,
+                    nftTokenId = row.get("nft_token_id", String::class.java)!!
+                )
+            }
+            .all()
+    }
+
+}

--- a/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftWithNft.kt
+++ b/src/main/kotlin/com/api/wallet/domain/walletNft/repository/WalletNftWithNft.kt
@@ -1,0 +1,10 @@
+package com.api.wallet.domain.walletNft.repository
+
+
+data class WalletNftWithNft(
+    val id: Long,
+    val walletId: Long,
+    val nftId: Long,
+    val nftTokenAddress: String,
+    val nftTokenId: String,
+)

--- a/src/main/kotlin/com/api/wallet/service/api/WalletService.kt
+++ b/src/main/kotlin/com/api/wallet/service/api/WalletService.kt
@@ -6,7 +6,6 @@ import com.api.wallet.domain.user.Users
 import com.api.wallet.domain.user.repository.UserRepository
 import com.api.wallet.domain.wallet.Wallet
 import com.api.wallet.domain.wallet.repository.WalletRepository
-import com.api.wallet.enums.ChainType
 import com.api.wallet.enums.NetworkType
 import com.api.wallet.service.infura.InfuraApiService
 import com.api.wallet.util.Util.convertNetworkTypeToChainType
@@ -56,7 +55,7 @@ class WalletService(
     private fun createUserAndWallet(address: String, network: Network): Mono<Wallet> {
         return userRepository.save(Users(nickName = "Unknown"))
                 .flatMap { user ->
-                    walletRepository.insert(Wallet(
+                    walletRepository.save(Wallet(
                         address = address,
                         userId = user.id!!,
                         networkType = network.type!!,
@@ -76,13 +75,5 @@ class WalletService(
         return infuraApiService.getBalance(wallet.address, chainType)
             .map { wallet.updateBalance(it) }
             .flatMap { walletRepository.save(it)  }
-    }
-
-    private fun convertNetworkTypeToChainType(networkType: NetworkType): ChainType {
-        return when (networkType) {
-            NetworkType.ETHEREUM -> ChainType.ETHEREUM_MAINNET
-            NetworkType.POLYGON -> ChainType.POLYGON_MAINNET
-
-        }
     }
 }

--- a/src/main/resources/db/postgresql/migration/V1__Initial_schema.sql
+++ b/src/main/resources/db/postgresql/migration/V1__Initial_schema.sql
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS network (
 );
 
 CREATE TABLE IF NOT EXISTS wallet (
-    address VARCHAR(255) PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
+    address VARCHAR(255) NOT NULL,
     balance DECIMAL(19, 4) NOT NULL,
     created_At BIGINT,
     updated_At BIGINT,
@@ -28,25 +29,28 @@ CREATE TABLE IF NOT EXISTS wallet (
     );
 
 CREATE TABLE IF NOT EXISTS nft (
-    token_address VARCHAR(255) PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
+    token_id VARCHAR(255) NOT NULL,
+    token_address VARCHAR(255) NOT NULL,
     network_type varchar(100) REFERENCES network(type)
 );
 
 CREATE TABLE IF NOT EXISTS transaction (
     id SERIAL PRIMARY KEY,
-    nft_id VARCHAR(255) REFERENCES nft(token_address),
+    nft_id BIGINT REFERENCES nft(id),
     to_address VARCHAR(255) NOT NULL,
     from_address VARCHAR(255) NOT NULL,
     amount INT,
     value NUMERIC,
     hash VARCHAR(255),
     block_timestamp BIGINT,
-    wallet_id VARCHAR(255) REFERENCES wallet(address)
+    wallet_id BIGINT REFERENCES wallet(id)
 );
 
 CREATE TABLE IF NOT EXISTS wallet_nft (
     id SERIAL PRIMARY KEY,
-    wallet_id VARCHAR(255) REFERENCES wallet(address),
-    nft_id VARCHAR(255) REFERENCES nft(token_address)
-)
+    wallet_id BIGINT REFERENCES wallet(id),
+    nft_id BIGINT REFERENCES nft(id),
+    amount INT
+);
 

--- a/src/test/kotlin/com/api/wallet/ValidatorTest.kt
+++ b/src/test/kotlin/com/api/wallet/ValidatorTest.kt
@@ -119,7 +119,7 @@ class ValidatorTest(
     @Test
     fun tansferasdas() {
         val address = "0x01b72b4aa3f66f213d62d53e829bc172a6a72867"
-        val pagebale = PageRequest.of(2,4)
+        val pagebale = PageRequest.of(0,20)
         val networkType = NetworkType.POLYGON
 
         val transaction: Page<Transaction>? = walletTransactionService.readAllTransactions(address,networkType,pagebale).block()
@@ -139,7 +139,7 @@ class ValidatorTest(
     @Test
     fun readAllNfts() {
         val address = "0x01b72b4aa3f66f213d62d53e829bc172a6a72867"
-        val pagebale = PageRequest.of(0,3)
+        val pagebale = PageRequest.of(0,10)
         val nftList= nftService.readAllNftByWallet(address,null,pagebale).block()
 
             println("total element : "+nftList?.totalElements)


### PR DESCRIPTION
**관련 이슈** #10 

#2 해당이슈 참고 
테이블 설계당시 간과하던 사실이 있었음, 지갑 주소를 키로 뒀을시 해당 지갑에 network가 추가되면서 wallet테이블에 network만 다르게 추가되어야 되는데 지갑주소를 PK로 두기때문에 에러가 발생함

또한 nft를 식별하는건 nft의 token 주소가 아닌 token주소와 token_Id임

**그래서 내가 해결방법은 wallet(address,networkType) / nft(address,tokenId)를 복합키로 두자라고 생각함**

하지만 안타깝게도 r2dbc는 복합키를 지원하지 않는다는거였음
https://github.com/spring-projects/spring-data-relational/issues/574
5년이 지난 아직도 지원을 안한다니 R2DBC를 사용하면서 JPA 찬양만 더 하게됨

댓글에서 dto클래스를 만들어 복합키로 설정해보라는 설명이 나와있어서 복합키를 사용해보려고함

## 못먹어도 GO 삽질 시작

```kotlin
@Table("wallet")
data class Wallet(
    @Id val id: WalletId,
    val userId: Long,
    var balance: BigDecimal,
    val createdAt: Long? = System.currentTimeMillis(),
    var updatedAt: Long? = System.currentTimeMillis()
)

data class WalletId(
    val address: String,
    val networkType: String,
)

CREATE TABLE IF NOT EXISTS wallet (
    address VARCHAR(255) NOT NULL,
    balance DECIMAL(19, 4) NOT NULL,
    created_At BIGINT,
    updated_At BIGINT,
    user_id BIGINT NOT NULL,
    network_type VARCHAR(100) NOT NULL,
        CONSTRAINT fk_users
             FOREIGN KEY (user_id)
             REFERENCES users(id),
        CONSTRAINT fk_network
            FOREIGN KEY (network_type)
            REFERENCES network(type),
        PRIMARY KEY (address, network_type)
);

```

   "SELECT * FROM wallet WHERE address = $1 AND network_type = $2"  실행 후 wallet을 잘 가져오길 기대했지만 
  객체에 데이터바인딩 안되는 문제가 발생함 ..."not supported xxxxxx"
  
  ```kotlin
   override fun findById(address: String, networkType: String): Mono<Wallet> {
         val query =
            "SELECT * FROM wallet WHERE address = $1 AND network_type = $2"

        return r2dbcEntityTemplate.databaseClient.sql(query)
            .bind(0, address)
            .bind(1, networkType)
            .map { row, metadata ->
                Wallet(
                    id = WalletId(address = row.get("address", String::class.java)!!,
                        networkType = row.get("network_type", String::class.java)!!),
                    userId = (row.get("user_id") as Number).toLong(),
                    balance = row.get("balance", BigDecimal::class.java)!!,
                    createdAt = (row.get("created_at") as Number).toLong(),
                    updatedAt = (row.get("updated_at") as Number).toLong(),
                )
            }.first()
    }
  ```
  이렇게 직접 객체매핑을 해줘야된다는 단점이있음 
  마찬가지로 inser문 ,update문에서도 파라미터를 바인딩해줘서 insert쿼리와 Update쿼리를 작성해줘야된다는 단점이 있었음 
  **복합키 관리에 대한 어려움을느낌..**
  wallet과 nft는 연관관계 테이블이 많기때문에, 연관관계인 테이블을 insert하려고 할때에도 직접 query를 작성해야됨 
 
  
  4시간동안 삽질 후 
### 결론 :  그냥 PK를 따로두고 필드로 두기로 함 

태초의 JDBC로 돌아간 느낌이라  NFT서버에서는 JPA를 사용할까 심히 고민중임
  
 
   
